### PR TITLE
Pause Menu added

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -75,6 +75,12 @@ jump={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
 ]
 }
+pause={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194306,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/scenes/levels/level 1/level_1.tscn
+++ b/scenes/levels/level 1/level_1.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="TileSet" uid="uid://cw3lyx0oi4ur" path="res://resources/tileset.tres" id="1_e1eqq"]
 [ext_resource type="PackedScene" uid="uid://c5ectkst4kcax" path="res://scenes/player/player.tscn" id="2_e1eqq"]
-[ext_resource type="PackedScene" path="res://scenes/manager/level_manager.tscn" id="2_s13yo"]
+[ext_resource type="PackedScene" uid="uid://6hs8h7kjruje" path="res://scenes/manager/level_manager.tscn" id="2_s13yo"]
 [ext_resource type="PackedScene" uid="uid://bmg2xrmwbsban" path="res://scenes/manager/inventory_manager.tscn" id="2_tyixm"]
 [ext_resource type="PackedScene" uid="uid://h06dc54ft1qa" path="res://scenes/enemies/frog.tscn" id="3_jkir6"]
 [ext_resource type="PackedScene" uid="uid://d1dyky7fq2mu8" path="res://scenes/ui/hud.tscn" id="4_tad2h"]
@@ -11,7 +11,7 @@
 [ext_resource type="Resource" uid="uid://cnsudgfi7boal" path="res://resources/inventory/key_blue.tres" id="8_bjle8"]
 [ext_resource type="Resource" uid="uid://bxgaxa5rrjio4" path="res://resources/inventory/key_green.tres" id="9_wls5t"]
 [ext_resource type="PackedScene" uid="uid://c3jhm7sck1126" path="res://scenes/item/animated_item.tscn" id="10_wls5t"]
-[ext_resource type="PackedScene" path="res://scenes/item/test_victory.tscn" id="12_i43rp"]
+[ext_resource type="PackedScene" uid="uid://c2xqnsg381n1a" path="res://scenes/item/test_victory.tscn" id="12_i43rp"]
 
 [node name="Level 1" type="Node2D"]
 

--- a/scenes/levels/level 1/level_1.tscn
+++ b/scenes/levels/level 1/level_1.tscn
@@ -47,6 +47,11 @@ position = Vector2(1990, 108)
 
 [node name="CoinBase" parent="Items" instance=ExtResource("10_wls5t")]
 position = Vector2(471, 396)
+count = 9
+
+[node name="CoinBase2" parent="Items" instance=ExtResource("10_wls5t")]
+position = Vector2(673, 576)
+count = 9
 
 [node name="KeyBase" parent="Items" instance=ExtResource("6_70c7p")]
 position = Vector2(1246, 428)

--- a/scenes/manager/level_manager.gd
+++ b/scenes/manager/level_manager.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 
 
 func _process(delta: float) -> void:
-	if Input.is_action_pressed("pause"):
+	if Input.is_action_just_pressed("pause"):
 		if pause_screen_scene == null: return
 		var pause_screen_instance = pause_screen_scene.instantiate()
 		add_child(pause_screen_instance)

--- a/scenes/manager/level_manager.gd
+++ b/scenes/manager/level_manager.gd
@@ -1,10 +1,18 @@
 extends Node
 
 @export var end_screen_scene: PackedScene
+@export var pause_screen_scene: PackedScene
 
 
 func _ready() -> void:
 	GameEvents.game_over.connect(on_game_over)
+
+
+func _process(delta: float) -> void:
+	if Input.is_action_pressed("pause"):
+		if pause_screen_scene == null: return
+		var pause_screen_instance = pause_screen_scene.instantiate()
+		add_child(pause_screen_instance)
 
 
 func on_game_over(success: bool):

--- a/scenes/manager/level_manager.tscn
+++ b/scenes/manager/level_manager.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=3 format=3 uid="uid://6hs8h7kjruje"]
+[gd_scene load_steps=4 format=3 uid="uid://6hs8h7kjruje"]
 
 [ext_resource type="Script" uid="uid://cetqpk35lgq0y" path="res://scenes/manager/level_manager.gd" id="1_e3djy"]
 [ext_resource type="PackedScene" uid="uid://c2f6b3cfl3oi1" path="res://scenes/ui/end_screen.tscn" id="2_1bs8u"]
+[ext_resource type="PackedScene" uid="uid://copkir107fge" path="res://scenes/ui/pause_menu.tscn" id="3_15wy8"]
 
 [node name="LevelManager" type="Node"]
 script = ExtResource("1_e3djy")
 end_screen_scene = ExtResource("2_1bs8u")
+pause_screen_scene = ExtResource("3_15wy8")

--- a/scenes/ui/hud.tscn
+++ b/scenes/ui/hud.tscn
@@ -55,6 +55,7 @@ texture = ExtResource("4_136eg")
 [node name="InventoryContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+theme_override_constants/separation = -8
 
 [node name="HUDInventoryItem" parent="MarginContainer/VBoxContainer/InventoryContainer" instance=ExtResource("5_136eg")]
 layout_mode = 2

--- a/scenes/ui/hud_inventory_item.gd
+++ b/scenes/ui/hud_inventory_item.gd
@@ -4,7 +4,8 @@ extends HBoxContainer
 
 @onready var item_texture: TextureRect = $ItemTexture
 @onready var count_container: HBoxContainer = $CountContainer
-@onready var count_texture: TextureRect = $CountContainer/CountTexture
+@onready var ones_count_texture: TextureRect = %OnesCountTexture
+@onready var tens_count_texture: TextureRect = %TensCountTexture
 
 
 func update_item_display(item: InventoryObject, current_inventory: Dictionary):
@@ -13,11 +14,19 @@ func update_item_display(item: InventoryObject, current_inventory: Dictionary):
 	update_count(count)
 
 
+## Updates the number textures. No multiplier if the count is only 1.
+## Starts as a single digit, adds second digit only at 10-99. Cap of 99.
 func update_count(count: int): 
-	count = min(count, 9) # Maximum of 9 until/unless handling 10s places, etc, is introduced
-	if count > 1:
+	count = min(count, 99)
+	if count > 9:
 		toggle_counter(true)
-		count_texture.texture = number_texture.numbers[count]
+		tens_count_texture.texture = number_texture.numbers[count / 10]
+		ones_count_texture.texture = number_texture.numbers[count % 10]
+		tens_count_texture.visible = true
+	elif count > 1:
+		toggle_counter(true)
+		ones_count_texture.texture = number_texture.numbers[count]
+		tens_count_texture.visible = false
 	else:
 		toggle_counter(false)
 

--- a/scenes/ui/hud_inventory_item.tscn
+++ b/scenes/ui/hud_inventory_item.tscn
@@ -12,6 +12,7 @@ offset_bottom = 64.0
 size_flags_horizontal = 0
 size_flags_vertical = 0
 mouse_filter = 2
+theme_override_constants/separation = -16
 script = ExtResource("1_due7h")
 number_texture = ExtResource("2_v4n70")
 
@@ -27,6 +28,7 @@ layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
 mouse_filter = 2
+theme_override_constants/separation = -24
 
 [node name="MultiplierTexture" type="TextureRect" parent="CountContainer"]
 custom_minimum_size = Vector2(32, 32)
@@ -34,6 +36,16 @@ layout_mode = 2
 texture = ExtResource("3_v4n70")
 expand_mode = 3
 
-[node name="CountTexture" type="TextureRect" parent="CountContainer"]
+[node name="DigitsContainer" type="HBoxContainer" parent="CountContainer"]
+layout_mode = 2
+theme_override_constants/separation = -32
+
+[node name="TensCountTexture" type="TextureRect" parent="CountContainer/DigitsContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+texture = ExtResource("4_65b3l")
+
+[node name="OnesCountTexture" type="TextureRect" parent="CountContainer/DigitsContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 texture = ExtResource("4_65b3l")

--- a/scenes/ui/pause_menu.gd
+++ b/scenes/ui/pause_menu.gd
@@ -20,9 +20,10 @@ func _ready() -> void:
 	%OptionsButton.pressed.connect(on_options_button_pressed)
 	%QuitButton.pressed.connect(on_quit_button_pressed)
 	
-	var level_name = get_parent().owner.name
-	if level_name == null: return
-	description_label.text = level_name
+	var level_name
+	if get_parent().owner: # Check that the scene is correctly added as a child
+		level_name = get_parent().owner.name
+		description_label.text = level_name
 
 
 func _process(delta: float) -> void:

--- a/scenes/ui/pause_menu.gd
+++ b/scenes/ui/pause_menu.gd
@@ -1,0 +1,42 @@
+extends CanvasLayer
+
+@export var menu_scene: PackedScene
+@export var options_scene: PackedScene
+
+var current_scene: PackedScene
+
+@onready var title_label: Label = %TitleLabel
+@onready var description_label: Label = %DescriptionLabel
+@onready var restart_button: Button = %RestartButton
+@onready var menu_button: Button = %MenuButton
+@onready var options_button: Button = %OptionsButton
+@onready var quit_button: Button = %QuitButton
+
+
+func _ready() -> void:
+	get_tree().paused = true
+	%RestartButton.pressed.connect(on_restart_button_pressed)
+	%MenuButton.pressed.connect(on_menu_button_pressed)
+	%OptionsButton.pressed.connect(on_options_button_pressed)
+	%QuitButton.pressed.connect(on_quit_button_pressed)
+
+
+func on_restart_button_pressed():
+	get_tree().paused = false
+	get_tree().reload_current_scene()
+
+
+func on_menu_button_pressed():
+	get_tree().paused = false
+	if menu_scene == null: queue_free()
+	get_tree().change_scene_to_packed(menu_scene)
+
+
+func on_options_button_pressed():
+	get_tree().paused = false
+	if options_scene == null: queue_free()
+	get_tree().change_scene_to_packed(options_scene)
+
+
+func on_quit_button_pressed():
+	get_tree().quit()

--- a/scenes/ui/pause_menu.gd
+++ b/scenes/ui/pause_menu.gd
@@ -19,6 +19,16 @@ func _ready() -> void:
 	%MenuButton.pressed.connect(on_menu_button_pressed)
 	%OptionsButton.pressed.connect(on_options_button_pressed)
 	%QuitButton.pressed.connect(on_quit_button_pressed)
+	
+	var level_name = get_parent().owner.name
+	if level_name == null: return
+	description_label.text = level_name
+
+
+func _process(delta: float) -> void:
+	if Input.is_action_just_pressed("pause"):
+		get_tree().paused = false
+		queue_free()
 
 
 func on_restart_button_pressed():

--- a/scenes/ui/pause_menu.gd.uid
+++ b/scenes/ui/pause_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://7kxdjxwiyapx

--- a/scenes/ui/pause_menu.tscn
+++ b/scenes/ui/pause_menu.tscn
@@ -1,0 +1,79 @@
+[gd_scene load_steps=3 format=3 uid="uid://copkir107fge"]
+
+[ext_resource type="Script" uid="uid://7kxdjxwiyapx" path="res://scenes/ui/pause_menu.gd" id="1_6tw0m"]
+[ext_resource type="PackedScene" uid="uid://qx3mjuixtfuj" path="res://scenes/screen/level select/level_select.tscn" id="2_0lmf7"]
+
+[node name="PauseMenu" type="CanvasLayer"]
+process_mode = 2
+script = ExtResource("1_6tw0m")
+menu_scene = ExtResource("2_0lmf7")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+process_mode = 2
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="MarginContainer"]
+process_mode = 2
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/PanelContainer"]
+process_mode = 2
+layout_mode = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="TextVBoxContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/MarginContainer"]
+process_mode = 2
+layout_mode = 2
+theme_override_constants/separation = 16
+
+[node name="TitleLabel" type="Label" parent="MarginContainer/PanelContainer/MarginContainer/TextVBoxContainer"]
+unique_name_in_owner = true
+process_mode = 2
+layout_mode = 2
+theme_type_variation = &"HeaderLarge"
+text = "PAUSED"
+horizontal_alignment = 1
+
+[node name="DescriptionLabel" type="Label" parent="MarginContainer/PanelContainer/MarginContainer/TextVBoxContainer"]
+unique_name_in_owner = true
+process_mode = 2
+layout_mode = 2
+text = "Current Level"
+horizontal_alignment = 1
+
+[node name="ButtonVBoxContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/MarginContainer/TextVBoxContainer"]
+process_mode = 2
+layout_mode = 2
+
+[node name="RestartButton" type="Button" parent="MarginContainer/PanelContainer/MarginContainer/TextVBoxContainer/ButtonVBoxContainer"]
+unique_name_in_owner = true
+process_mode = 2
+layout_mode = 2
+text = "Retry"
+
+[node name="MenuButton" type="Button" parent="MarginContainer/PanelContainer/MarginContainer/TextVBoxContainer/ButtonVBoxContainer"]
+unique_name_in_owner = true
+process_mode = 2
+layout_mode = 2
+text = "Level Select"
+
+[node name="OptionsButton" type="Button" parent="MarginContainer/PanelContainer/MarginContainer/TextVBoxContainer/ButtonVBoxContainer"]
+unique_name_in_owner = true
+process_mode = 2
+layout_mode = 2
+text = "Options"
+
+[node name="QuitButton" type="Button" parent="MarginContainer/PanelContainer/MarginContainer/TextVBoxContainer/ButtonVBoxContainer"]
+unique_name_in_owner = true
+process_mode = 2
+layout_mode = 2
+text = "Quit"


### PR DESCRIPTION
Adds a pause menu when pressing Esc or Tab (set under `pause` in the Input Map). Unpause by pressing the pause key again. Currently displays the level name, and 4 buttons: Retry, Level Select, Options, and Quit.
Options will just fallback to closing the pause screen, until a scene is added.

I also tweaked the UI layout to be a little more compact, and added the ability to display inventory counts up to 99.